### PR TITLE
Modified Chapter 4 and 18

### DIFF
--- a/18. Config Settings and State.md
+++ b/18. Config Settings and State.md
@@ -9,47 +9,48 @@ Each component can have arbitrary configuration settings that will be saved as p
 Below is a login screen example where login credentials are stored in the view specific config object.
 
 ```kotlin
-class LoginScreen : View(), Initializable {
-    override val root: BorderPane by fxml()
+class LoginScreen : View() {
     val loginController: LoginController by inject()
-
-    val usernameField: Label by fxid()
-    val passwordField: Label by fxid()
-    val loginButton: Button by fxid()
-
-    init {
-        usernameField.text = config.string("username")
-        passwordField.text = config.string("password")
-
-        loginButton.setOnAction {
-            runAsync {
-                loginController.tryLogin(usernameField.text, passwordField.text)
-            } ui { success ->
-                if (success) {
-
-                    with(config) {
-                        set("username" to usernameField.text)
-                        set("password" to passwordField.text)
-                        save()
+    val username = SimpleStringProperty(this, "username", config.string("username"))
+    val password = SimpleStringProperty(this, "password", config.string("password"))
+    
+    override val root = form {
+       fieldset("Login") {
+           field("Username:") { textfield(username) }
+           field("Password:") { textfield(password) }
+           buttonbar {
+                button("Login").action {
+                    runAsync {
+                        loginController.tryLogin(username.value, password.value)
+                    } ui { success ->
+                        if (success) {
+                            with(config) {
+                                 set("username" to username.value)
+                                 set("password" to password.value)
+                                 save()
+                            }
+                            showMainScreen()
+                        }
                     }
-
-                    showMainScreen()
                 }
             }
-        }
+       }
     }
-
+    
     fun showMainScreen() {
         // hide LoginScreen and show the main UI of the application
     }
-
 }
 ```
 > Login screen with credentials stored in the view specific config object
 
-The UI is defined in *FXML* and basically contains two textfields and a button. When the view is loaded, we assign username and password values from the config object. These values might be null at this point, if no prior successful login was performed.
+The UI is defined with the `TornadoFx` type safe builders, which basically contains a `form` with two `TextField`'s and a `Button`.
+When the view is loaded, we assign the username and password values from the config object.
+These values might be null at this point, if no prior successful login was performed.
+We then bind the `username` and `password` to the corresponding `TextField`'s.
 
-We then define the action for the login button. Upon login, it calls the `loginController#tryLogin` function which takes the username and password from the input fields, calls out to the service and returns true or false.
+Last but not least, we define the action for the login button. Upon login, it calls the `loginController#tryLogin` function which takes the username and password from the `StringBindings` (which represent the input of the `TextField`s),
+calls out to the service and returns true or false.
 
 If the result is true, we update the username and password in the config object and calls save on it. Finally, we call `showMainScreen` which could hide the login screen and show the main screen of the application.
 

--- a/4. Basic Controls.md
+++ b/4. Basic Controls.md
@@ -51,7 +51,7 @@ class MyView : View() {
         with(root) {
             this += Button("Press Me").apply {
                 textFill = Color.RED
-                setOnAction { println("Button pressed!") }
+                action { println("Button pressed!") }
             }
         }
     }
@@ -75,7 +75,7 @@ class MyView : View() {
         with(root) {
             button("Press Me") {
                 textFill = Color.RED
-                setOnAction { println("Button pressed!") }
+                action { println("Button pressed!") }
             }
         }
     }
@@ -83,8 +83,10 @@ class MyView : View() {
 ```
 
 While this looks much cleaner, you might be wondering: "How did we just get rid of the `this +=` and `apply()` function call? And why are we using a function called `button()` instead of an actual `Button`?"
-
-We will not go too deep on how this is done, and you can always dig into the source code if you are curious. But essentially, the `VBox` (or any targetable component) has an extension function called `button()`. It accepts a text argument and an optional closure targeting a `Button` it will instantiate. When this function is called, it will create a `Button` with the specified text, apply the closure to it, add it to the `VBox` it was  called on, and then return it.
+We will not go too deep on how this is done, and you can always dig into the [source code](https://github.com/edvin/tornadofx/blob/master/src/main/java/tornadofx/Controls.kt#L234) if you are curious.
+But essentially, the `VBox` (or any targetable component) has an extension function called `button()`. 
+It accepts a text argument and an optional closure targeting a `Button` it will instantiate.
+When this function is called, it will create a `Button` with the specified text, apply the closure to it, add it to the `VBox` it was  called on, and then return it.
 
 Taking this efficiency further, you can override the `root` in a `View`, but assign it a builder function and avoid needing any `init` and `with()` blocks.
 
@@ -94,7 +96,7 @@ class MyView : View() {
     override val root = vbox {
         button("Press Me") {
             textFill = Color.RED
-            setOnAction { println("Button pressed!") }
+            action { println("Button pressed!") }
         }
     }
 }
@@ -147,7 +149,7 @@ class MyView : View() {
         }
         button("LOGIN") {
             useMaxWidth = true
-            setOnAction {
+            action {
                 println("Logging in as ${firstNameField.text} ${lastNameField.text}")
             }
         }
@@ -173,7 +175,7 @@ Within a `Pane`, this will add a `Button` with red text and print "Button presse
 ```kotlin
 button("Press Me") {
     textFill = Color.RED
-    setOnAction {
+    action {
         println("Button pressed!")
     }
 }
@@ -237,9 +239,7 @@ passwordfield("my_password") {
 You can create a `CheckBox` to quickly create a true/false state control and  optionally manipulate it with a block (Figure 4.8).
 
 ```kotlin
-checkbox("Admin Mode") {
-    setOnAction { println(isSelected) }
-}
+checkbox("Admin Mode").action { println(isSelected) }
 ```
 **Figure 4.9**
 
@@ -251,9 +251,7 @@ You can also provide a `Property<Boolean>` that will bind to its selection state
 ```kotlin
 val booleanProperty = SimpleBooleanProperty()
 
-checkbox("Admin Mode", booleanProperty) {
-    setOnAction { println(isSelected) }
-}
+checkbox("Admin Mode", booleanProperty).action { println(isSelected) }
 ```
 
 ### ComboBox
@@ -279,7 +277,7 @@ You do not need to specify the generic type if you declare the `values` as an ar
 val texasCities = FXCollections.observableArrayList("Austin",
         "Dallas","Midland","San Antonio","Fort Worth")
 
-combobox(values= texasCities)
+combobox(values = texasCities)
 ```
 
 You can also specify a `Property<T>` to be bound to the selected value.
@@ -299,11 +297,7 @@ combobox(selectedCity, texasCities)
 A `ToggleButton` is a button that expresses a true/false state depending on its selection state (Figure 4.11).
 
 ```kotlin
-togglebutton("OFF") {
-    setOnAction {
-        text = if (isSelected) "ON" else "OFF"
-    }
-}
+togglebutton("OFF").action { text = if (isSelected) "ON" else "OFF" }
 ```
 
 **Figure 4.11**
@@ -334,11 +328,7 @@ class MyView : View() {
 A `RadioButton` is the same functionality as a `ToggleButton` but with a different visual style. When it is selected, it "fills" in a circular control (Figure 4.13).
 
 ```kotlin
-radiobutton("Power User Mode") {
-    setOnAction {
-       println("Power User Mode: $isSelected")
-    }
-}
+radiobutton("Power User Mode").action { println("Power User Mode: $isSelected") }
 ```
 
 **Figure 4.13**
@@ -517,9 +507,7 @@ Keep in mind that many controls like `TableView` and `TreeTableView` already hav
 You can create a `Hyperlink` control to mimic the behavior of a typical hyperlink to a file, a website, or simply perform an action.
 
 ```kotlin
-hyperlink("Open File") {
-    setOnAction { println("Opening file...")}
-}
+hyperlink("Open File").action { println("Opening file...") }
 ```
 
 **Figure 4.22**


### PR DESCRIPTION
4. Basic Controls:
 * Changed all `setOnAction` to `action` which was released in 1.7.1
 * Replaced nested `action { }` with explicit function call if the only
   Statement was `action` like we discussed here:#288
 * Added link source code where button builder is implemented.
18. Config Settings and State
   * Tried to simplify the `LoginScreen` example to make it more `TornadoFx` like.
   * Adjusted the text to be inline with the code example.