### PR TITLE
 Sample Code in Component Documentation

### DIFF
--- a/part1/3. Components.md
+++ b/part1/3. Components.md
@@ -198,6 +198,7 @@ class MyView : View() {
                     input.value = ""
                 }
             }
+       }
     }
 }
 


### PR DESCRIPTION
Missing a "}" in one of the examples