### PR TITLE
Fixed bad Maven link

### DIFF
--- a/part1/2. Setting Up.md
+++ b/part1/2. Setting Up.md
@@ -49,7 +49,7 @@ Then this goes into `dependencies` block:
 
 ### Other Build Automation Solutions
 
-For instructions on how to use TornadoFX with other build automation solutions, please refer to the \[TornadoFX page at the Central Repository]([[http://search.maven.org/\#search\|gav\|1\|g%3A"no.tornado\](http://search.maven.org/\#search\|gav\|1\|g%3A"no.tornado](http://search.maven.org/#search|gav|1|g%3A"no.tornado]%28http://search.maven.org/#search|gav|1|g%3A"no.tornado))" AND a%3A"tornadofx")
+For instructions on how to use TornadoFX with other build automation solutions, please refer to the [TornadoFX page at the Central Repository](https://search.maven.org/artifact/no.tornado/tornadofx/)
 
 ## Manual Import
 


### PR DESCRIPTION
Fixed a malformed link to Maven Central. I also changed to a URL that should always take the user to the actual page instead of a listing of search results.