### PR TITLE
Add section on selecor types

### DIFF
--- a/part1/6. CSS.md
+++ b/part1/6. CSS.md
@@ -283,6 +283,53 @@ class MyView: View() {
 
 ![](https://i.imgur.com/rgT8Kfy.png)
 
+#### Other types of selectors
+
+TornadoFX supports selecting nodes based on their element name, ID, and style-class, and also has support for pseudo-classes. The following example shows how each of them can be used:
+
+```kotlin
+class MyStyle: Stylesheet() {
+    companion object {
+        val udp by csselement("UpsideDownPane")
+        val phantomZone by cssid()
+        val fancyPants by cssclass()
+        val interactive by csspseudoclass()
+    }
+
+    init {
+        udp {
+            fontSize = 20.px
+        }
+        phantomZone {
+            backgroundColor += c("black")
+        }
+        fancyPants {
+            backgroundColor += c("orange")
+        }
+        label and interactive {
+            textFill = c("green")
+        }
+    }
+}
+```
+
+And would result in the following CSS:
+
+```css
+UpsideDownPane {
+    -fx-font-size: 20px;
+}
+#phantom-zone {
+    -fx-background-color: #000000ff;
+}
+.fancy-pants {
+    -fx-background-color: #ff8000ff;
+}
+label:interactive {
+    -fx-test-fill: #008000ff;
+}
+```
+
 ### Multi-Value CSS Properties
 
 Some CSS properties accept multiple values, and TornadoFX Stylesheets can streamline this with the `multi()` function. This allows you to specify multiple values via a `varargs` parameter and let TornadoFX take care of the rest. For instance, you can nest multiple background colors and insets into a control (Figure 6.5).


### PR DESCRIPTION
Including a quick example for elements, classes, IDs, and pseudo-classes.

This probably isn't ready to be merged, as my technical writing skills leave much to be desired. @thomasnield may want to look it over.