### PR TITLE
Maven openjdk instructions

### DIFF
--- a/part1/2. Setting Up.md
+++ b/part1/2. Setting Up.md
@@ -27,6 +27,8 @@ dependencies {
 
 ## Maven
 
+### If you are using Oracle JDK
+
 To import TornadoFX with Maven, add the following dependency to your POM file. Provide the desired version number for the  `x.y.z` placeholder.
 
 Goes into kotlin-maven-plugin block:
@@ -47,7 +49,87 @@ Then this goes into `dependencies` block:
 </dependency>
 ```
 
-### Other Build Automation Solutions
+### If you are using OpenJDK
+
+On Ubuntu 19.10, there is no longer any clean way to run OpenJDK 8 with JFX. OpenJDK 8 does not include the JFX module libraries -- JFX support for OpenJDK is commonly provided by OpenJFX, which has a maven distribution as well as packages in various Linux distributions. However, the OpenJFX versions are tied to JDK versions (e.g. OpenJFX 8 is compatible with OpenJDK 8), and unfortunately the OpenJFX 8 version is not available in Ubuntu 19.10's packages, nor does it compile from source using the packaged OpenJDK 8.
+
+The upshot of this is that if you wish to continue using OpenJDK (on Ubuntu), your options are:
+1) Stay on OpenJDK 8 but install OpenJFX 8 system wide by adding older dependencies to your system (e.g. https://bugs.launchpad.net/ubuntu/+source/openjfx/+bug/1799946/comments/7)
+
+2) Alternately, you can bite the bullet and upgrade to OpenJDK 11, and install OpenJFX via Maven. This solution is as follows:
+
+a) Upgrade to OpenJDK 11 via your system's packaging tools.
+
+b) Add maven dependencies:
+
+```
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+```
+
+c) Add the OpenJFX builder to your build/plugins section:
+```
+<build>
+   <plugins>
+       ...
+	<plugin>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-maven-plugin</artifactId>
+            <version>0.0.3</version>
+            <configuration>
+                <mainClass>MyMainApp</mainClass>
+            </configuration>
+        </plugin>
+   </plugins>
+</build>
+```
+
+d) Set the language level in your maven build to 11:
+```
+<build>
+   <plugins>
+	...
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+                <release>11</release>
+            </configuration>
+        </plugin>
+    </plugins>
+</plugin>
+```
+
+e) Finally, add src/main/kotlin/module-info.java, to set up permissioning in Java 11's module system.
+
+```
+module yourmodulename {
+    requires javafx.controls;
+    requires javafx.graphics;
+    requires tornadofx;
+    requires kotlin.stdlib;
+    opens your.package.to.ui.classes;
+}
+```
+If you are using IntelliJ, it will provide helpful prompts to add any additional modules that you may need for the build to succeed with your app. StackOverflow has a plethora of questions from Java programmers switching to the module system for the first time, so if you run into a module permissions related issue, google the error message for a solution.
+
+(Variations on this section for other platforms are welcomed.)
+
+## Other Build Automation Solutions
 
 For instructions on how to use TornadoFX with other build automation solutions, please refer to the [TornadoFX page at the Central Repository](https://search.maven.org/artifact/no.tornado/tornadofx/)
 

--- a/part1/2. Setting Up.md
+++ b/part1/2. Setting Up.md
@@ -51,7 +51,7 @@ Then this goes into `dependencies` block:
 
 ### If you are using OpenJDK
 
-On Ubuntu 19.10, there is no longer any clean way to run OpenJDK 8 with JFX. OpenJDK 8 does not include the JFX module libraries -- JFX support for OpenJDK is commonly provided by OpenJFX, which has a maven distribution as well as packages in various Linux distributions. However, the OpenJFX versions are tied to JDK versions (e.g. OpenJFX 8 is compatible with OpenJDK 8), and unfortunately the OpenJFX 8 version is not available in Ubuntu 19.10's packages, nor does it compile from source using the packaged OpenJDK 8.
+On Ubuntu 19.10, there is no longer any clean way to run OpenJDK 8 with JFX. OpenJDK in general does not include the JFX module libraries -- JFX support for OpenJDK is commonly provided by OpenJFX, which has a maven distribution as well as packages in various Linux distributions. However, the OpenJFX versions are tied to JDK versions (e.g. OpenJFX 8 is compatible with OpenJDK 8), and unfortunately the OpenJFX 8 version is not available in Ubuntu 19.10's packages, nor does it compile from source using the packaged OpenJDK 8.
 
 The upshot of this is that if you wish to continue using OpenJDK (on Ubuntu), your options are:
 1) Stay on OpenJDK 8 but install OpenJFX 8 system wide by adding older dependencies to your system (e.g. https://bugs.launchpad.net/ubuntu/+source/openjfx/+bug/1799946/comments/7)


### PR DESCRIPTION
Added section describing how to use Maven OpenJFX dependencies. This is no longer doable on OpenJDK 8, so I additionally included quick & dirty getting started instructions for OpenJDK 11, given that many Kotlin developers may not yet have made the jump.