### PR TITLE
Fix ListView example

### DIFF
--- a/part1/5. Data Controls.md
+++ b/part1/5. Data Controls.md
@@ -25,7 +25,7 @@ You can also provide it an `ObservableList` of items up front and omit the type 
 
 ```kotlin
 val greekLetters = listOf("Alpha","Beta",
-        "Gamma","Delta","Epsilon").observable()
+        "Gamma","Delta","Epsilon").asObservable()
 
 listview(greekLetters) {
     selectionModel.selectionMode = SelectionMode.MULTIPLE
@@ -34,7 +34,7 @@ listview(greekLetters) {
 
 Like most data controls, keep in mind that by default the `ListView` will call `toString()` to render the text for each item in your domain class. To render anything else, you will need to create your own custom cell formatting.
 
-> To read about custom cell formatting and nodes for a `ListView`, read Appendix A3 - Custom Cell Formatting in ListView
+> To read about custom cell formatting and nodes for a `ListView`, read the section "Custom Cell Formatting in ListView" in Part 2 - Advanced Data Controls
 
 ### TableView
 


### PR DESCRIPTION
The existing ListView example was using the deprecated `.observable()` method and referred to a nonexistent appendix.

This should fix both of those issues.